### PR TITLE
Add set_tag and set_tags methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.2)
+    ssf (0.0.3)
       google-protobuf (= 3.3.0)
 
 GEM
@@ -23,4 +23,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.15.1
+   1.15.2

--- a/lib/ssf/ssf_methods.rb
+++ b/lib/ssf/ssf_methods.rb
@@ -59,6 +59,9 @@ module Ssf
 
 
     def set_tag(name, value)
+      if name.nil?
+        return
+      end
       self.tags[name] = value
     end
 

--- a/lib/ssf/ssf_methods.rb
+++ b/lib/ssf/ssf_methods.rb
@@ -62,6 +62,12 @@ module Ssf
       self.tags[name] = value
     end
 
+    def set_tags(tags)
+      if tags.is_a?(Hash)
+        self.tags = self.tags.merge(tags)
+      end
+    end
+
     def self.clean_tags(tags)
       tmp = {}
       tags.map do |k, v|

--- a/lib/ssf/ssf_methods.rb
+++ b/lib/ssf/ssf_methods.rb
@@ -58,6 +58,10 @@ module Ssf
     end
 
 
+    def set_tag(name, value)
+      self.tags[name] = value
+    end
+
     def self.clean_tags(tags)
       tmp = {}
       tags.map do |k, v|

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.2'
+  s.version = '0.0.3'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Standard Sensor Format'
   s.description = 'Ruby client for the Standard Sensor Format'

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -23,6 +23,14 @@ module SSFTest
       assert(s.id == s2.id)
     end
 
+    def test_set_tag
+      s = Ssf::SSFSpan.new({
+        id: 123456,
+      })
+      s.set_tag('foo', 'bar')
+      assert_equal(s.tags['foo'], 'bar')
+    end
+
     def test_client_send
       s = Ssf::SSFSpan.new({
         id: 123456,

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -31,6 +31,20 @@ module SSFTest
       assert_equal(s.tags['foo'], 'bar')
     end
 
+    def test_set_tags
+      s = Ssf::SSFSpan.new({
+        id: 123456,
+      })
+      s.set_tag('foo', 'bar')
+
+      s.set_tags({
+        'foo' => 'gorch',
+        'fart' => 'eww',
+      })
+      assert_equal(s.tags['foo'], 'gorch')
+      assert_equal(s.tags['fart'], 'eww')
+    end
+
     def test_client_send
       s = Ssf::SSFSpan.new({
         id: 123456,

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -45,6 +45,19 @@ module SSFTest
       assert_equal(s.tags['fart'], 'eww')
     end
 
+    def test_set_tag_with_nils
+      s = Ssf::SSFSpan.new({
+        id: 123456,
+      })
+      # We need to ensure that if someone accidentally passes a nill we
+      # don't blow up!
+      assert_nothing_raised do
+        s.set_tag(nil, nil)
+        s.set_tags(nil)
+      end
+
+    end
+
     def test_client_send
       s = Ssf::SSFSpan.new({
         id: 123456,


### PR DESCRIPTION
#### Summary
Add a `set_tag` and `set_tags` method to Span.


#### Motivation
Users will inevitably want to add tags onto an existing span for convenience! This beats accessing the hash directly.

#### Test plan
Added a unit test!

#### Rollout/monitoring/revert plan
Merge, use as a dep elsewhere.

r? @aditya-stripe  
