### PR TITLE
Do some symbolism.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.3)
+    ssf (0.0.4)
       google-protobuf (= 3.3.0)
 
 GEM

--- a/lib/ssf/ssf_methods.rb
+++ b/lib/ssf/ssf_methods.rb
@@ -57,12 +57,11 @@ module Ssf
       self.tags['name'] = name
     end
 
-
     def set_tag(name, value)
       if name.nil?
         return
       end
-      self.tags[name.to_s] = value
+      self.tags[name.to_s] = value.to_s
     end
 
     def set_tags(tags)

--- a/lib/ssf/ssf_methods.rb
+++ b/lib/ssf/ssf_methods.rb
@@ -62,12 +62,14 @@ module Ssf
       if name.nil?
         return
       end
-      self.tags[name] = value
+      self.tags[name.to_s] = value
     end
 
     def set_tags(tags)
       if tags.is_a?(Hash)
-        self.tags = self.tags.merge(tags)
+        tags.map do |k, v|
+          self.set_tag(k, v)
+        end
       end
     end
 

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.3'
+  s.version = '0.0.4'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Standard Sensor Format'
   s.description = 'Ruby client for the Standard Sensor Format'

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -49,9 +49,16 @@ module SSFTest
       s = Ssf::SSFSpan.new({
         id: 123456,
       })
+      # Make sure we stringify everything.
       assert_nothing_raised do
         s.set_tag(:foo, 'bar')
+        assert_equal(s.tags['foo'], 'bar')
+        s.set_tag('foo', :bar)
+        assert_equal(s.tags['foo'], 'bar')
         s.set_tags({ foo: 'bar' })
+        assert_equal(s.tags['foo'], 'bar')
+        s.set_tags({ 'foo' => :bar })
+        assert_equal(s.tags['foo'], 'bar')
       end
     end
 

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -45,6 +45,16 @@ module SSFTest
       assert_equal(s.tags['fart'], 'eww')
     end
 
+    def test_set_tags_with_symbols
+      s = Ssf::SSFSpan.new({
+        id: 123456,
+      })
+      assert_nothing_raised do
+        s.set_tag(:foo, 'bar')
+        s.set_tags({ foo: 'bar' })
+      end
+    end
+
     def test_set_tag_with_nils
       s = Ssf::SSFSpan.new({
         id: 123456,


### PR DESCRIPTION
#### Summary
Deal with `Symbol`s passed into tag methods.

#### Motivation
If someone calls `set_tag` or `set_tags` with a `Symbol` as the key (very common) or the value, we blow up today with a type exception.

We need to dtrt if people pass symbols in. We do some testing for this in the tag cleaning stuff, but we can't put `Symbol`s into a protobuf map, so we have to verify at insertion time and `to_s`.

#### Test plan
Unit tests!

r? @yasha-stripe 