### PR TITLE
Don't encode packets until we have to.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.5)
+    ssf (0.0.7)
       google-protobuf (= 3.3.0)
 
 GEM

--- a/lib/ssf/client.rb
+++ b/lib/ssf/client.rb
@@ -24,7 +24,9 @@ module SSF
     end
 
     def send_to_socket(span)
-      @socket.send(span, 0)
+      message = Ssf::SSFSpan.encode(self)
+
+      @socket.send(message, 0)
     end
 
     def start_span(operation: '', tags: {}, parent: nil)

--- a/lib/ssf/client.rb
+++ b/lib/ssf/client.rb
@@ -23,8 +23,8 @@ module SSF
       socket
     end
 
-    def send_to_socket(message)
-      @socket.send(message, 0)
+    def send_to_socket(span)
+      @socket.send(span, 0)
     end
 
     def start_span(operation: '', tags: {}, parent: nil)
@@ -39,9 +39,9 @@ module SSF
         start_span_from_context(operation: operation, tags: new_tags, trace_id: parent.trace_id, parent_id: parent.id)
       else
         start_span_from_context(operation: operation, tags: tags)
-      end 
+      end
     end
-    
+
     def start_span_from_context(operation: '', tags: {}, trace_id: nil, parent_id: nil)
       span_id = SecureRandom.random_number(2**32 - 1)
       start = Time.now.to_f * 1_000_000_000

--- a/lib/ssf/client.rb
+++ b/lib/ssf/client.rb
@@ -24,7 +24,7 @@ module SSF
     end
 
     def send_to_socket(span)
-      message = Ssf::SSFSpan.encode(self)
+      message = Ssf::SSFSpan.encode(span)
 
       @socket.send(message, 0)
     end

--- a/lib/ssf/local_buffering_client.rb
+++ b/lib/ssf/local_buffering_client.rb
@@ -8,8 +8,8 @@ module SSF
       @service = service
     end
 
-    def send_to_socket(message)
-      @buffer << message
+    def send_to_socket(span)
+      @buffer << span
     end
 
     def reset

--- a/lib/ssf/logging_client.rb
+++ b/lib/ssf/logging_client.rb
@@ -5,8 +5,8 @@ module SSF
       nil
     end
 
-    def send_to_socket(message)
-      puts("would have sent #{message}")
+    def send_to_socket(span)
+      puts("would have sent #{span}")
     end
   end
 end

--- a/lib/ssf/ssf_methods.rb
+++ b/lib/ssf/ssf_methods.rb
@@ -16,9 +16,7 @@ module Ssf
         set_name(name)
       end
 
-      packet = Ssf::SSFSpan.encode(self)
-
-      @client.send_to_socket(packet)
+      @client.send_to_socket(self)
       self
     end
 

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.6'
+  s.version = '0.0.7'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Standard Sensor Format'
   s.description = 'Ruby client for the Standard Sensor Format'

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -81,9 +81,10 @@ module SSFTest
       })
 
       c = SSF::LocalBufferingClient.new()
-      c.send_to_socket(Ssf::SSFSpan.encode(s))
+      c.send_to_socket(s)
 
       assert_equal(1, c.buffer.length, 'Expected to find one span in client')
+      assert_equal(123456, c.buffer[0].id)
       c.reset
       assert_equal(0, c.buffer.length, 'Expected buffer to be cleared')
     end
@@ -94,7 +95,7 @@ module SSFTest
       })
 
       c = SSF::LoggingClient.new(host: '127.0.01', port: '8128')
-      c.send_to_socket(Ssf::SSFSpan.encode(s))
+      c.send_to_socket(s)
     end
 
     def test_full_client_send


### PR DESCRIPTION
#### Summary
Don't encode packets until the client is ready.

#### Motivation
In the buffering test client we don't want to encode as bytes. That's annoying in a test. So let's defer marshaling or whatever to the client. :)

#### Needs
I already verified this is what I need in bapi, so mostly am looking for a rubberstamp BUT if you have other ideas to improve the testing interface they are welcome.

#### Test plan
Added a test!

r? @stripe/observability 