### PR TITLE
Switch to use name instead of operation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.9)
+    ssf (0.0.10)
       google-protobuf (= 3.3.0)
 
 GEM
@@ -24,4 +24,4 @@ DEPENDENCIES
   ssf!
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/lib/ssf/client.rb
+++ b/lib/ssf/client.rb
@@ -38,7 +38,7 @@ module SSF
       end
     end
 
-    def start_span(operation: '', tags: {}, parent: nil)
+    def start_span(name: '', tags: {}, parent: nil)
       if parent
         new_tags = {}
         parent.tags.each do |key, value|
@@ -47,13 +47,13 @@ module SSF
           end
         end
         new_tags = Ssf::SSFSpan.clean_tags(tags.merge(new_tags))
-        start_span_from_context(operation: operation, tags: new_tags, trace_id: parent.trace_id, parent_id: parent.id)
+        start_span_from_context(name: name, tags: new_tags, trace_id: parent.trace_id, parent_id: parent.id)
       else
-        start_span_from_context(operation: operation, tags: tags)
+        start_span_from_context(name: name, tags: tags)
       end
     end
 
-    def start_span_from_context(operation: '', tags: {}, trace_id: nil, parent_id: nil)
+    def start_span_from_context(name: '', tags: {}, trace_id: nil, parent_id: nil)
       span_id = SecureRandom.random_number(2**32 - 1)
       start = Time.now.to_f * 1_000_000_000
       # the trace_id is set to span_id for root spans
@@ -62,7 +62,7 @@ module SSF
         trace_id: span_id,
         start_timestamp: start,
         service: @service,
-        operation: operation,
+        name: name,
         tags: Ssf::SSFSpan.clean_tags(tags)
         })
       span.client = self

--- a/lib/ssf/sample_pb.rb
+++ b/lib/ssf/sample_pb.rb
@@ -37,9 +37,13 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :end_timestamp, :int64, 6
     optional :error, :bool, 7
     optional :service, :string, 8
-    optional :operation, :string, 9
     repeated :metrics, :message, 10, "ssf.SSFSample"
     map :tags, :string, :string, 11
+    optional :indicator, :bool, 12
+    optional :name, :string, 13
+  end
+  add_message "ssf.SSFSpanCollection" do
+    repeated :spans, :message, 1, "ssf.SSFSpan"
   end
 end
 
@@ -48,4 +52,5 @@ module Ssf
   SSFSample::Metric = Google::Protobuf::DescriptorPool.generated_pool.lookup("ssf.SSFSample.Metric").enummodule
   SSFSample::Status = Google::Protobuf::DescriptorPool.generated_pool.lookup("ssf.SSFSample.Status").enummodule
   SSFSpan = Google::Protobuf::DescriptorPool.generated_pool.lookup("ssf.SSFSpan").msgclass
+  SSFSpanCollection = Google::Protobuf::DescriptorPool.generated_pool.lookup("ssf.SSFSpanCollection").msgclass
 end

--- a/lib/ssf/ssf_methods.rb
+++ b/lib/ssf/ssf_methods.rb
@@ -10,22 +10,20 @@ module Ssf
       end
       self.end_timestamp = time.to_i
 
-      name = self.tags['name']
-      if name == nil || name == ''
-        name = caller_locations(1,1)[0].label
-        set_name(name)
+      if name.nil? || name == ''
+        self.name = caller_locations(1, 1)[0].label
       end
 
       @client.send_to_socket(self)
     end
 
-    def child_span(operation: '', tags: {})
+    def child_span(name: '', tags: {})
       puts "WARN: this method is deprecated."
       span_id = SecureRandom.random_number(2**32 - 1)
       trace_id = self.trace_id
       start = Time.now.to_f * 1_000_000_000
       service = self.service
-      operation = operation
+      name = name
       new_tags = {}
       self.tags.each do |key, value|
         if key != 'name'
@@ -42,16 +40,12 @@ module Ssf
         trace_id: trace_id,
         start_timestamp: start,
         service: service,
-        operation: operation,
+        name: name,
         tags: new_tags,
         parent_id: parent
       })
       span.client = self.client
       span
-    end
-
-    def set_name(name)
-      self.tags['name'] = name
     end
 
     def set_tag(name, value)

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.9'
+  s.version = '0.0.10'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Simple Sensor Format'
   s.description = 'Ruby client for the Simple Sensor Format'

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -138,9 +138,9 @@ module SSFTest
 
     def test_child_span
       c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128', service: 'test-srv')
-      span = c.start_span(operation: 'op1', tags: {'tag1' => 'value1'})
+      span = c.start_span(name: 'op1', tags: {'tag1' => 'value1'})
 
-      child1 = c.start_span(operation: 'op2', tags: {'tag2' => 'value2'}, parent: span)
+      child1 = c.start_span(name: 'op2', tags: {'tag2' => 'value2'}, parent: span)
 
       child1.finish
       span.finish
@@ -157,7 +157,7 @@ module SSFTest
 
     def test_from_context
       c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128', service: 'test-srv')
-      span = c.start_span_from_context(operation: 'op1',
+      span = c.start_span_from_context(name: 'op1',
                                 tags: { 'tag1' => 'value1' },
                                 trace_id: 5,
                                 parent_id: 10)
@@ -178,7 +178,7 @@ module SSFTest
         'a_number' => 5,
       }
 
-      span = c.start_span(operation: 'op1',
+      span = c.start_span(name: 'op1',
                                 tags: tags)
 
       assert_equal('bar', span.tags['foo'])
@@ -197,8 +197,8 @@ module SSFTest
         'a_number' => 5,
       }
 
-      span = c.start_span(operation: 'op1', tags: tags)
-      span = c.start_span(operation: 'op2', tags: tags, parent: span)
+      span = c.start_span(name: 'op1', tags: tags)
+      span = c.start_span(name: 'op2', tags: tags, parent: span)
 
       assert_equal(span.tags["foo"], "bar")
       assert_equal(span.tags["something"], nil)

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -84,7 +84,7 @@ module SSFTest
 
     def test_failing_client
       c = FailingClient.new(host: '127.0.01', port: '8128')
-      span = c.start_span(operation: 'run test')
+      span = c.start_span(name: 'run test')
       result = span.finish
 
       refute(result, "Failing client didn't fail")
@@ -94,7 +94,7 @@ module SSFTest
       UDPSocket.any_instance.stubs(:send).raises(StandardError.new("explosion"))
 
       c = SSF::Client.new(host: '127.0.01', port: '8128')
-      span = c.start_span(operation: 'run test')
+      span = c.start_span(name: 'run test')
       result = span.finish
 
       refute(result, "Failing client didn't fail")
@@ -127,7 +127,7 @@ module SSFTest
 
     def test_full_client_send
       c = SSF::LoggingClient.new(host: '127.0.01', port: '8128', service: 'test-srv')
-      span = c.start_span(operation: 'run test')
+      span = c.start_span(name: 'run test')
       result = span.finish
       assert(result, "Logging client didn't return true")
 


### PR DESCRIPTION
#### Summary
Replace `operation` with `name` and scour the use of the `name` tag from all the things.

#### Motivation
We've decided that `name` is a more ergonomic… name… for the span. This replaces the use of operation.

This PR is jumping ahead of [this PR to SSF](https://github.com/stripe/veneur/pull/212) and already has the new protobuf. We'll need to patch veneur to make this all work. 😠 

#### Test plan
Existing tests.

r? @aditya-stripe 