### PR TITLE
Ensure that errors sending to a UDP socket don't bubble up.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ gemspec
 gem 'google-protobuf', '3.3.0'
 gem 'test-unit'
 gem 'rake'
+
+group :test do
+  gem 'mocha', '1.1.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     google-protobuf (3.3.0)
+    metaclass (0.0.4)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
     power_assert (1.0.2)
     rake (12.0.0)
     test-unit (3.2.4)
@@ -18,9 +21,10 @@ PLATFORMS
 
 DEPENDENCIES
   google-protobuf (= 3.3.0)
+  mocha (= 1.1.0)
   rake
   ssf!
   test-unit
 
 BUNDLED WITH
-   1.15.2
+   1.15.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.7)
+    ssf (0.0.8)
       google-protobuf (= 3.3.0)
 
 GEM

--- a/lib/ssf/client.rb
+++ b/lib/ssf/client.rb
@@ -9,6 +9,7 @@ module SSF
     attr_reader :port
 
     attr_reader :service
+    attr_reader :socket
 
     def initialize(host: DEFAULT_HOST, port: DEFAULT_PORT, service: '', max_buffer_size: 50)
       @host = host
@@ -26,7 +27,15 @@ module SSF
     def send_to_socket(span)
       message = Ssf::SSFSpan.encode(span)
 
-      @socket.send(message, 0)
+      begin
+        # Despite UDP being connectionless, some implementations — including
+        # ruby — will throw an exception if there's nothing listening. We will
+        # rescue it to avoid any problems for our client.
+        @socket.send(message, 0)
+        true
+      rescue StandardError
+        false
+      end
     end
 
     def start_span(operation: '', tags: {}, parent: nil)

--- a/lib/ssf/local_buffering_client.rb
+++ b/lib/ssf/local_buffering_client.rb
@@ -10,6 +10,7 @@ module SSF
 
     def send_to_socket(span)
       @buffer << span
+      true
     end
 
     def reset

--- a/lib/ssf/logging_client.rb
+++ b/lib/ssf/logging_client.rb
@@ -7,6 +7,7 @@ module SSF
 
     def send_to_socket(span)
       puts("would have sent #{span}")
+      true
     end
   end
 end

--- a/lib/ssf/ssf_methods.rb
+++ b/lib/ssf/ssf_methods.rb
@@ -17,7 +17,6 @@ module Ssf
       end
 
       @client.send_to_socket(self)
-      self
     end
 
     def child_span(operation: '', tags: {})

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.7'
+  s.version = '0.0.8'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Standard Sensor Format'
   s.description = 'Ruby client for the Standard Sensor Format'


### PR DESCRIPTION
#### Summary
Protect our callers from exceptions when calling `send`.

#### Motivation
Friday we hit some errors because the underlying Veneur on some API boxes was restarted. We neglected to catch these exceptions in the client as we've done in our old client. This code ensures that we catch the exception and also that we return the success of failure.

#### Needs
This PR changes the behavior of `finish` such that it returns a true or false instead of returning the span. To my knowledge we're not using this in any sort of chaining setup so this seems like a good change.

We can adjust our users to examine the returned value and emit a metric or log an error.

#### Test plan
Added unit tests. This lurks in mocha, as I don't know else to stub out a failure of `UDPSocket`. I could be convinced to wire up `SSF::Client` different so that it has some wrapper that throws an exception instead of relying on mocha… but our internal code uses it as did our old client.

r? @yasha-stripe 