### PR TITLE
Use minitest and put deps in gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ sample.proto
 *.swo
 *.swn
 pkg
+*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-
-gem 'google-protobuf', '3.3.0'
-gem 'test-unit'
-gem 'rake'
-
-group :test do
-  gem 'mocha', '1.1.0'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,27 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.8)
+    ssf (0.0.9)
       google-protobuf (= 3.3.0)
+      minitest (= 5.8.4)
+      rake (= 10.2.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
     google-protobuf (3.3.0)
     metaclass (0.0.4)
+    minitest (5.8.4)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    power_assert (1.0.2)
-    rake (12.0.0)
-    test-unit (3.2.4)
-      power_assert
+    rake (10.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  google-protobuf (= 3.3.0)
   mocha (= 1.1.0)
-  rake
   ssf!
-  test-unit
 
 BUNDLED WITH
    1.15.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,6 @@ PATH
   specs:
     ssf (0.0.9)
       google-protobuf (= 3.3.0)
-      minitest (= 5.8.4)
-      rake (= 10.2.2)
 
 GEM
   remote: https://rubygems.org/
@@ -20,7 +18,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  minitest (= 5.8.4)
   mocha (= 1.1.0)
+  rake (= 10.2.2)
   ssf!
 
 BUNDLED WITH

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.8'
+  s.version = '0.0.9'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Simple Sensor Format'
   s.description = 'Ruby client for the Simple Sensor Format'
@@ -13,5 +13,8 @@ spec = Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
-  s.add_runtime_dependency 'google-protobuf', ["= 3.3.0"]
+  s.add_runtime_dependency 'google-protobuf', ['= 3.3.0']
+  s.add_runtime_dependency 'minitest', ['= 5.8.4']
+  s.add_runtime_dependency 'rake', ['= 10.2.2']
+  s.add_development_dependency 'mocha', ['= 1.1.0']
 end

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -14,7 +14,7 @@ spec = Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
   s.add_runtime_dependency 'google-protobuf', ['= 3.3.0']
-  s.add_runtime_dependency 'minitest', ['= 5.8.4']
-  s.add_runtime_dependency 'rake', ['= 10.2.2']
+  s.add_development_dependency 'minitest', ['= 5.8.4']
+  s.add_development_dependency 'rake', ['= 10.2.2']
   s.add_development_dependency 'mocha', ['= 1.1.0']
 end


### PR DESCRIPTION
#### Summary
Use the gemspec for deps instead of mixing with Gemfile. Also use minitest in of test-unit.

#### Motivation
We evidently prefer minitest, so fixing that. Also we had a mix of deps in two places, so I combined them into one.

#### Test plan
Existing tests pass.

r? @stripe/observability 