### PR TITLE
Add indicator as a keyword for SSF::Client#start_span

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.10)
+    ssf (0.0.11)
       google-protobuf (= 3.3.0)
 
 GEM

--- a/lib/ssf/client.rb
+++ b/lib/ssf/client.rb
@@ -38,7 +38,7 @@ module SSF
       end
     end
 
-    def start_span(name: '', tags: {}, parent: nil)
+    def start_span(name: '', tags: {}, parent: nil, indicator: false)
       if parent
         new_tags = {}
         parent.tags.each do |key, value|
@@ -47,19 +47,20 @@ module SSF
           end
         end
         new_tags = Ssf::SSFSpan.clean_tags(tags.merge(new_tags))
-        start_span_from_context(name: name, tags: new_tags, trace_id: parent.trace_id, parent_id: parent.id)
+        start_span_from_context(name: name, tags: new_tags, trace_id: parent.trace_id, parent_id: parent.id, indicator: indicator)
       else
-        start_span_from_context(name: name, tags: tags)
+        start_span_from_context(name: name, tags: tags, indicator: indicator)
       end
     end
 
-    def start_span_from_context(name: '', tags: {}, trace_id: nil, parent_id: nil)
+    def start_span_from_context(name: '', tags: {}, trace_id: nil, parent_id: nil, indicator: false)
       span_id = SecureRandom.random_number(2**32 - 1)
       start = Time.now.to_f * 1_000_000_000
       # the trace_id is set to span_id for root spans
       span = Ssf::SSFSpan.new({
         id: span_id,
         trace_id: span_id,
+        indicator: indicator,
         start_timestamp: start,
         service: @service,
         name: name,

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.10'
+  s.version = '0.0.11'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Simple Sensor Format'
   s.description = 'Ruby client for the Simple Sensor Format'

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -204,5 +204,16 @@ module SSFTest
       assert_equal(span.tags["something"], nil)
       assert_equal(span.tags["a_number"], "5")
     end
+
+    def test_indicator_span
+      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128', service: 'test-srv')
+
+      indicator_span = c.start_span(name: 'op1', indicator: true)
+      not_indicator_span = c.start_span(name: 'op2', indicator: false)
+      default_span = c.start_span(name: 'op3')
+      assert_equal(true, indicator_span.indicator)
+      assert_equal(false, not_indicator_span.indicator)
+      assert_equal(false, default_span.indicator)
+    end
   end
 end


### PR DESCRIPTION
#### Summary
Adds the `indicator` option to `SSF::Client#start_span` so that we can denote indicator spans.

#### Motivation
Bringing ssf-ruby up to par with the SSF spec in terms of functionality.

#### Test plan
Added tests to test the cases of `indicator` being set to true, false, or nothing.

r? @aditya-stripe 
