### PR TITLE
Relax version requirement on google-protobuf gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.12)
-      google-protobuf (= 3.3.0)
+    ssf (0.0.13)
+      google-protobuf (~> 3.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    google-protobuf (3.3.0)
+    google-protobuf (3.3.0-universal-darwin)
     metaclass (0.0.4)
     minitest (5.8.4)
     mocha (1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    google-protobuf (3.3.0-universal-darwin)
+    google-protobuf (3.3.0)
     metaclass (0.0.4)
     minitest (5.8.4)
     mocha (1.1.0)

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.12'
+  s.version = '0.0.13'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Sensor Sensibility Format'
   s.description = 'Ruby client for the Sensor Sensibility Format'
@@ -13,7 +13,7 @@ spec = Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
-  s.add_runtime_dependency 'google-protobuf', ['= 3.3.0']
+  s.add_runtime_dependency 'google-protobuf', ['~> 3.3']
   s.add_development_dependency 'minitest', ['= 5.8.4']
   s.add_development_dependency 'rake', ['= 10.2.2']
   s.add_development_dependency 'mocha', ['= 1.1.0']


### PR DESCRIPTION
#### Summary
Relax version requirement on google-protobuf gem: >= 3.3, < 4.0 instead of exactly 3.3.0

#### Motivation
Be able to upgrade the google-protobuf gem when it's used for more than ssf (e.g. in pay-server)

An alternative would be to cut a new version of this gem pointing at a newer protobuf, but that would be awkward for my use case because I actually want to point at a private fork of google-protobuf

#### Test plan
None (open to suggestions, though)

#### Rollout/monitoring/revert plan
None

r? @aditya-stripe (run)
cc @stripe/observability 