### PR TITLE
Make 'service' required

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.13)
+    ssf (0.0.14)
       google-protobuf (~> 3.3)
 
 GEM

--- a/lib/ssf/client.rb
+++ b/lib/ssf/client.rb
@@ -11,7 +11,7 @@ module SSF
     attr_reader :service
     attr_reader :socket
 
-    def initialize(host: DEFAULT_HOST, port: DEFAULT_PORT, service: '', max_buffer_size: 50)
+    def initialize(host: DEFAULT_HOST, port: DEFAULT_PORT, service:, max_buffer_size: 50)
       @host = host
       @port = port
       @service = service

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.13'
+  s.version = '0.0.14'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Sensor Sensibility Format'
   s.description = 'Ruby client for the Sensor Sensibility Format'

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -83,7 +83,7 @@ module SSFTest
     end
 
     def test_failing_client
-      c = FailingClient.new(host: '127.0.01', port: '8128')
+      c = FailingClient.new(host: '127.0.01', port: '8128', service: 'test-srv')
       span = c.start_span(name: 'run test')
       result = span.finish
 
@@ -93,7 +93,7 @@ module SSFTest
     def test_failing_udp_client
       UDPSocket.any_instance.stubs(:send).raises(StandardError.new("explosion"))
 
-      c = SSF::Client.new(host: '127.0.01', port: '8128')
+      c = SSF::Client.new(host: '127.0.01', port: '8128', service: 'test-srv')
       span = c.start_span(name: 'run test')
       result = span.finish
 
@@ -120,7 +120,7 @@ module SSFTest
         id: 123456,
       })
 
-      c = SSF::LoggingClient.new(host: '127.0.01', port: '8128')
+      c = SSF::LoggingClient.new(host: '127.0.01', port: '8128', service: 'test-srv')
       result = c.send_to_socket(s)
       assert(result, "Logging client didn't return true")
     end


### PR DESCRIPTION
#### Summary
Lightstep collectors crash with an undefined service; it's likely going to be an error even when that is fixed. Prevent creation of a client without a service defined so that we avoid footguns.

#### Test plan
Not much to test since this is a strict subset of the previous behavior; I need to pull this into our main codebase to verify functionality with existing code -- though I don't see any way we'd be relying on this ability from before.

r? @ChimeraCoder 