### PR TITLE
Added frozen_string_literal and ability to override services in spans

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.14)
+    ssf (0.0.15)
       google-protobuf (~> 3.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    google-protobuf (3.3.0)
+    google-protobuf (3.6.1)
     metaclass (0.0.4)
     minitest (5.8.4)
     mocha (1.1.0)
@@ -24,4 +24,4 @@ DEPENDENCIES
   ssf!
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/lib/ssf.rb
+++ b/lib/ssf.rb
@@ -1,4 +1,5 @@
 require 'ssf/sample_pb.rb'
+require 'ssf/base_client.rb'
 require 'ssf/client.rb'
 require 'ssf/ssf_methods.rb'
 require 'ssf/logging_client.rb'

--- a/lib/ssf/base_client.rb
+++ b/lib/ssf/base_client.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+require 'socket'
+
+module SSF
+  class BaseClient
+    DEFAULT_HOST = '127.0.0.1'
+    DEFAULT_PORT = 8128
+
+    attr_reader :host
+    attr_reader :port
+
+    attr_reader :socket
+
+    def initialize(host: DEFAULT_HOST, port: DEFAULT_PORT, max_buffer_size: 50)
+      @host = host || DEFAULT_HOST
+      @port = port || DEFAULT_PORT
+      @socket = connect_to_socket(host, port)
+    end
+
+    def connect_to_socket(host, port)
+      socket = UDPSocket.new
+      socket.connect(host, port)
+      socket
+    end
+
+    def send_to_socket(span)
+      message = Ssf::SSFSpan.encode(span)
+
+      begin
+        # Despite UDP being connectionless, some implementations — including
+        # ruby — will throw an exception if there's nothing listening. We will
+        # rescue it to avoid any problems for our client.
+        @socket.send(message, 0)
+        true
+      rescue StandardError
+        false
+      end
+    end
+
+    def start_span(name: '', tags: {}, parent: nil, indicator: false, service:)
+      tags = Ssf::SSFSpan.clean_tags(tags)
+      if parent
+        start_span_from_context(
+          name: name,
+          tags: Hash[parent.tags].merge!(tags),
+          trace_id: parent.trace_id,
+          parent_id: parent.id,
+          indicator: indicator,
+          clean_tags: false,
+          service: service
+        )
+      else
+        start_span_from_context(
+          name: name,
+          tags: tags,
+          indicator: indicator,
+          clean_tags: false,
+          service: service
+        )
+      end
+    end
+
+    def start_span_from_context(name: '', tags: {}, trace_id: nil, parent_id: nil, indicator: false, clean_tags: true, service:)
+      span_id = SecureRandom.random_number(2**32 - 1)
+      start = Time.now.to_f * 1_000_000_000
+      # the trace_id is set to span_id for root spans
+      span = Ssf::SSFSpan.new({
+        id: span_id,
+        trace_id: span_id,
+        indicator: indicator,
+        start_timestamp: start,
+        service: service,
+        name: name,
+        tags: clean_tags ? Ssf::SSFSpan.clean_tags(tags) : tags,
+      })
+      span.client = self
+      if trace_id != nil
+        span.trace_id = trace_id
+      end
+      if parent_id != nil
+        span.parent_id = parent_id
+      end
+      span
+    end
+  end
+end

--- a/lib/ssf/client.rb
+++ b/lib/ssf/client.rb
@@ -3,91 +3,38 @@ require 'socket'
 
 module SSF
   class Client
-    DEFAULT_HOST = '127.0.0.1'.freeze
-    DEFAULT_PORT = 8128
-
-    attr_reader :host
-    attr_reader :port
-
+    attr_reader :base_client
     attr_reader :service
-    attr_reader :socket
 
-    def initialize(host: DEFAULT_HOST, port: DEFAULT_PORT, service: nil, max_buffer_size: 50)
-      @host = host
-      @port = port
+    def initialize(host: nil, port: nil, max_buffer_size: nil, service:)
+      @base_client = SSF::BaseClient.new(
+        host: host,
+        port: port,
+        max_buffer_size: max_buffer_size
+      )
       @service = service
-      @socket = connect_to_socket(host, port)
     end
 
-    def connect_to_socket(host, port)
-      socket = UDPSocket.new
-      socket.connect(host, port)
-      socket
-    end
-
-    def send_to_socket(span)
-      message = Ssf::SSFSpan.encode(span)
-
-      begin
-        # Despite UDP being connectionless, some implementations — including
-        # ruby — will throw an exception if there's nothing listening. We will
-        # rescue it to avoid any problems for our client.
-        @socket.send(message, 0)
-        true
-      rescue StandardError
-        false
-      end
-    end
-
-    def start_span(name: '', tags: {}, parent: nil, indicator: false, override_service: nil)
-      tags = Ssf::SSFSpan.clean_tags(tags)
-      if parent
-        start_span_from_context(
-          name: name,
-          tags: Hash[parent.tags].merge!(tags),
-          trace_id: parent.trace_id,
-          parent_id: parent.id,
-          indicator: indicator,
-          clean_tags: false,
-          override_service: override_service
-        )
-      else
-        start_span_from_context(
-          name: name,
-          tags: tags,
-          indicator: indicator,
-          clean_tags: false,
-          override_service: override_service
-        )
-      end
-    end
-
-    def start_span_from_context(name: '', tags: {}, trace_id: nil, parent_id: nil, indicator: false, clean_tags: true, override_service: nil)
-      span_service = override_service || @service
-      unless span_service
-        raise ArgumentError.new("You must either pass service to start_span_from_context or when you initialize the client")
-      end
-
-      span_id = SecureRandom.random_number(2**32 - 1)
-      start = Time.now.to_f * 1_000_000_000
-      # the trace_id is set to span_id for root spans
-      span = Ssf::SSFSpan.new({
-        id: span_id,
-        trace_id: span_id,
-        indicator: indicator,
-        start_timestamp: start,
-        service: span_service,
+    def start_span(name: '', tags: {}, parent: nil, indicator: false)
+      base_client.start_span(
         name: name,
-        tags: clean_tags ? Ssf::SSFSpan.clean_tags(tags) : tags,
-      })
-      span.client = self
-      if trace_id != nil
-        span.trace_id = trace_id
-      end
-      if parent_id != nil
-        span.parent_id = parent_id
-      end
-      span
+        tags: tags,
+        parent: parent,
+        indicator: indicator,
+        service: service
+      )
+    end
+
+    def start_span_from_context(name: '', tags: {}, trace_id: nil, parent_id: nil, indicator: false, clean_tags: true)
+      base_client.start_span_from_context(
+        name: name,
+        tags: tags,
+        trace_id: trace_id,
+        parent_id: parent_id,
+        indicator: indicator,
+        clean_tags: clean_tags,
+        service: service 
+      )
     end
   end
 end

--- a/lib/ssf/local_buffering_client.rb
+++ b/lib/ssf/local_buffering_client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SSF
   class LocalBufferingClient < Client
 

--- a/lib/ssf/logging_client.rb
+++ b/lib/ssf/logging_client.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 module SSF
-  class LoggingClient < Client
-
+  class LoggingClient < SSF::BaseClient
     def connect_to_socket(host, port)
       nil
     end

--- a/lib/ssf/logging_client.rb
+++ b/lib/ssf/logging_client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SSF
   class LoggingClient < Client
 

--- a/lib/ssf/ssf_methods.rb
+++ b/lib/ssf/ssf_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'socket'
 
 module Ssf

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.14'
+  s.version = '0.0.15'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Sensor Sensibility Format'
   s.description = 'Ruby client for the Sensor Sensibility Format'

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -215,5 +215,20 @@ module SSFTest
       assert_equal(false, not_indicator_span.indicator)
       assert_equal(false, default_span.indicator)
     end
+
+    def test_start_span_service
+      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128', service: 'test-srv')
+      span = c.start_span(name: 'op', override_service: 'override-srv')
+      assert_equal('override-srv', span.service)
+    end
+
+    def test_no_service
+      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128')
+
+      ex = assert_raises(ArgumentError) do
+        c.start_span(name: 'op')
+      end
+      assert_equal("You must either pass service to start_span_from_context or when you initialize the client", ex.message)
+    end
   end
 end

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -4,8 +4,7 @@ require 'ssf'
 require 'securerandom'
 
 module SSFTest
-  class FailingClient < SSF::Client
-
+  class FailingClient < SSF::BaseClient
     def connect_to_socket(host, port)
       nil
     end
@@ -83,8 +82,8 @@ module SSFTest
     end
 
     def test_failing_client
-      c = FailingClient.new(host: '127.0.01', port: '8128', service: 'test-srv')
-      span = c.start_span(name: 'run test')
+      c = FailingClient.new(host: '127.0.01', port: '8128')
+      span = c.start_span(name: 'run test', service: 'test-srv')
       result = span.finish
 
       refute(result, "Failing client didn't fail")
@@ -93,8 +92,8 @@ module SSFTest
     def test_failing_udp_client
       UDPSocket.any_instance.stubs(:send).raises(StandardError.new("explosion"))
 
-      c = SSF::Client.new(host: '127.0.01', port: '8128', service: 'test-srv')
-      span = c.start_span(name: 'run test')
+      c = SSF::BaseClient.new(host: '127.0.01', port: '8128')
+      span = c.start_span(name: 'run test', service: 'test-srv')
       result = span.finish
 
       refute(result, "Failing client didn't fail")
@@ -120,14 +119,14 @@ module SSFTest
         id: 123456,
       })
 
-      c = SSF::LoggingClient.new(host: '127.0.01', port: '8128', service: 'test-srv')
+      c = SSF::LoggingClient.new(host: '127.0.01', port: '8128')
       result = c.send_to_socket(s)
       assert(result, "Logging client didn't return true")
     end
 
     def test_full_client_send
-      c = SSF::LoggingClient.new(host: '127.0.01', port: '8128', service: 'test-srv')
-      span = c.start_span(name: 'run test')
+      c = SSF::LoggingClient.new(host: '127.0.01', port: '8128')
+      span = c.start_span(name: 'run test', service: 'test-srv')
       result = span.finish
       assert(result, "Logging client didn't return true")
 
@@ -137,10 +136,10 @@ module SSFTest
     end
 
     def test_child_span
-      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128', service: 'test-srv')
-      span = c.start_span(name: 'op1', tags: {'tag1' => 'value1'})
+      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128')
+      span = c.start_span(name: 'op1', tags: {'tag1' => 'value1'}, service: 'test-srv')
 
-      child1 = c.start_span(name: 'op2', tags: {'tag2' => 'value2'}, parent: span)
+      child1 = c.start_span(name: 'op2', tags: {'tag2' => 'value2'}, parent: span, service: 'test-srv')
 
       child1.finish
       span.finish
@@ -156,11 +155,12 @@ module SSFTest
     end
 
     def test_from_context
-      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128', service: 'test-srv')
+      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128')
       span = c.start_span_from_context(name: 'op1',
                                 tags: { 'tag1' => 'value1' },
                                 trace_id: 5,
-                                parent_id: 10)
+                                parent_id: 10,
+                                service: 'test-srv')
 
       assert(span.trace_id == 5)
       assert(span.parent_id == 10)
@@ -170,7 +170,7 @@ module SSFTest
     def test_start_span_context_tags_nonstrings
       # we should be able to handle passing in keys and values for
       # 'tags' that are not strings without throwing an exception
-      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128', service: 'test-srv')
+      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128')
 
       tags = {
         :foo => :bar,
@@ -178,9 +178,7 @@ module SSFTest
         'a_number' => 5,
       }
 
-      span = c.start_span(name: 'op1',
-                                tags: tags)
-
+      span = c.start_span(name: 'op1', tags: tags, service: 'test-srv')
       assert_equal('bar', span.tags['foo'])
       assert_equal(nil, span.tags['something'])
       assert_equal('5', span.tags['a_number'])
@@ -189,7 +187,7 @@ module SSFTest
     def test_child_span_tags_nonstrings
       # we should be able to handle passing in keys and values for
       # 'tags' that are not strings without throwing an exception
-      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128', service: 'test-srv')
+      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128')
 
       tags = {
         :foo => :bar,
@@ -197,8 +195,8 @@ module SSFTest
         'a_number' => 5,
       }
 
-      span = c.start_span(name: 'op1', tags: tags)
-      span = c.start_span(name: 'op2', tags: tags, parent: span)
+      span = c.start_span(name: 'op1', tags: tags, service: 'test-srv')
+      span = c.start_span(name: 'op2', tags: tags, parent: span, service: 'test-srv')
 
       assert_equal("bar", span.tags["foo"])
       assert_equal(nil, span.tags["something"])
@@ -206,29 +204,30 @@ module SSFTest
     end
 
     def test_indicator_span
-      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128', service: 'test-srv')
+      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128')
 
-      indicator_span = c.start_span(name: 'op1', indicator: true)
-      not_indicator_span = c.start_span(name: 'op2', indicator: false)
-      default_span = c.start_span(name: 'op3')
+      indicator_span = c.start_span(name: 'op1', indicator: true, service: 'test-srv')
+      not_indicator_span = c.start_span(name: 'op2', indicator: false, service: 'test-srv')
+      default_span = c.start_span(name: 'op3', service: 'test-srv')
       assert_equal(true, indicator_span.indicator)
       assert_equal(false, not_indicator_span.indicator)
       assert_equal(false, default_span.indicator)
     end
 
-    def test_start_span_service
-      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128', service: 'test-srv')
-      span = c.start_span(name: 'op', override_service: 'override-srv')
-      assert_equal('override-srv', span.service)
+    def test_client_span
+      c = SSF::Client.new(host: '127.0.0.1', port: '8128', service: 'test-srv')
+
+      span = c.start_span(name: 'op1')
+      assert_equal('test-srv', span.service)
     end
 
-    def test_no_service
-      c = SSF::LoggingClient.new(host: '127.0.0.1', port: '8128')
+    def test_client_span_context
+      c = SSF::Client.new(host: '127.0.0.1', port: '8128', service: 'test-srv')
 
-      ex = assert_raises(ArgumentError) do
-        c.start_span(name: 'op')
-      end
-      assert_equal("You must either pass service to start_span_from_context or when you initialize the client", ex.message)
+      span = c.start_span_from_context(name: 'op1', trace_id: 5, parent_id: 10)
+      assert_equal(5, span.trace_id)
+      assert_equal(10, span.parent_id)
+      assert_equal('test-srv', span.service)
     end
   end
 end


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

We have some internal use cases that want to override `service`, and with the `service` baked in at init time, we'd have to create a client per service which is more FDs. Since the client doesn't have any real state (besides this) it seems reasonable to allow overriding the service in `start_span`, since it also simplifies some optimizations.

I also added `# frozen_string_literal: true` while I was at it, because it's just generally a good practice.

cc @cory-stripe 