### PR TITLE
Fixed local buffering inheriting from Client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.15)
+    ssf (0.0.16)
       google-protobuf (~> 3.3)
 
 GEM

--- a/lib/ssf/local_buffering_client.rb
+++ b/lib/ssf/local_buffering_client.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 module SSF
-  class LocalBufferingClient < Client
-
+  class LocalBufferingClient < BaseClient
     attr_reader :buffer
 
-    def initialize(service: '')
+    def initialize
       @buffer = []
-      @service = service
     end
 
     def send_to_socket(span)

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.15'
+  s.version = '0.0.16'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Sensor Sensibility Format'
   s.description = 'Ruby client for the Sensor Sensibility Format'

--- a/test/ssf/sample_test.rb
+++ b/test/ssf/sample_test.rb
@@ -104,7 +104,7 @@ module SSFTest
         id: 123456,
       })
 
-      c = SSF::LocalBufferingClient.new()
+      c = SSF::LocalBufferingClient.new
       result = c.send_to_socket(s)
       assert(result, "Local client didn't return true")
 


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Sorry! I realized the `LocalBufferingClient` needs to inherit from `BaseClient`, since that's what has the `send_to_socket`.


cc @asf-stripe 

