### PR TITLE
Use 63 bits for generating span IDs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.16)
+    ssf (0.0.17)
       google-protobuf (~> 3.3)
 
 GEM
@@ -24,4 +24,4 @@ DEPENDENCIES
   ssf!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/lib/ssf/base_client.rb
+++ b/lib/ssf/base_client.rb
@@ -61,7 +61,7 @@ module SSF
     end
 
     def start_span_from_context(name: '', tags: {}, trace_id: nil, parent_id: nil, indicator: false, clean_tags: true, service:)
-      span_id = SecureRandom.random_number(2**32 - 1)
+      span_id = SecureRandom.random_number(2**63 - 1)
       start = Time.now.to_f * 1_000_000_000
       # the trace_id is set to span_id for root spans
       span = Ssf::SSFSpan.new({

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.16'
+  s.version = '0.0.17'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Sensor Sensibility Format'
   s.description = 'Ruby client for the Sensor Sensibility Format'


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Use a larger space to generate random span IDs and trace IDs


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @stripe/observability 