### PR TITLE
Avoid unnecessary allocations in clean_string & use cheaper methods in span construction

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ssf (0.0.18)
+    ssf (0.0.19)
       google-protobuf (~> 3.3)
 
 GEM

--- a/lib/ssf/base_client.rb
+++ b/lib/ssf/base_client.rb
@@ -60,9 +60,11 @@ module SSF
       end
     end
 
+    ID_MAX = 2**63 - 1
+
     def start_span_from_context(name: '', tags: {}, trace_id: nil, parent_id: nil, indicator: false, clean_tags: true, service:)
-      span_id = SecureRandom.random_number(2**63 - 1)
-      start = Time.now.to_f * 1_000_000_000
+      span_id = Random.rand(ID_MAX)
+      start = Process.clock_gettime(Process::CLOCK_REALTIME) * 1_000_000_000
       # the trace_id is set to span_id for root spans
       span = Ssf::SSFSpan.new({
         id: span_id,

--- a/lib/ssf/ssf_methods.rb
+++ b/lib/ssf/ssf_methods.rb
@@ -7,7 +7,7 @@ module Ssf
 
     def finish(time: nil)
       unless time
-        time = Time.now.to_f * 1_000_000_000
+        time = Process.clock_gettime(Process::CLOCK_REALTIME) * 1_000_000_000
       end
       self.end_timestamp = time.to_i
 

--- a/lib/ssf/ssf_methods.rb
+++ b/lib/ssf/ssf_methods.rb
@@ -73,8 +73,13 @@ module Ssf
     end
 
     def self.clean_string(str)
-      # assigning a non-utf8 string to a protobuf field will throw an exception
-      str.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+      str = str.to_s unless str.is_a?(String)
+      if str.encoding != Encoding::UTF_8 || !str.valid_encoding?
+        # assigning a non-utf8 string to a protobuf field will throw an exception
+        str.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+      else
+        str
+      end
     end
   end
 end

--- a/ssf-ruby.gemspec
+++ b/ssf-ruby.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'ssf'
-  s.version = '0.0.18'
+  s.version = '0.0.19'
   s.required_ruby_version = '>= 1.9.3'
   s.summary = 'Ruby client for the Sensor Sensibility Format'
   s.description = 'Ruby client for the Sensor Sensibility Format'


### PR DESCRIPTION
#### Summary
^

#### Motivation
pay-server spends ~0.8% of time in `SSF::BaseClient#start_span_from_context` and ~0.4% in `Ssf::SSFSpan.clean_string` in key methods per https://hubble.corp.stripe.com/queries/djudd/de43a824

Before:
```
[dev] main:0> s = 'foo_bar'; puts Benchmark.measure {1_000_000.times {clean_string(s)}}
  1.616000   0.000000   1.616000 (  1.617001)
[dev] main:0> puts Benchmark.measure {1_000_000.times {Time.now.to_f}}
  0.544000   0.004000   0.548000 (  0.547377)
[dev] main:0> x = 2**63-1; puts Benchmark.measure {1_000_000.times {SecureRandom.random_number(x)}}
  0.768000   1.068000   1.836000 (  1.836925)
```

After:
```
[dev] main:0> s = 'foo_bar'; puts Benchmark.measure {1_000_000.times {clean_string(s)}}
  0.124000   0.000000   0.124000 (  0.126248)
[dev] main:0> puts Benchmark.measure {1_000_000.times {Process.clock_gettime(Process::CLOCK_REALTIME)}}
  0.108000   0.000000   0.108000 (  0.107385)
[dev] main:0> x = 2**63-1; puts Benchmark.measure {1_000_000.times {Random.rand(x)}}
  0.268000   0.000000   0.268000 (  0.266199)
```

I can't think of a reason we'd need secure random numbers for span IDs.

#### Test plan
Existing tests (passing now - thanks @bobby-stripe !)

#### Rollout/monitoring/revert plan
Bump pay-server