### PR TITLE
build: fix travis tests, bump protobuf dep for Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-  - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 script: bundle exec rake test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    google-protobuf (3.6.1)
+    google-protobuf (3.11.3)
     metaclass (0.0.4)
     minitest (5.8.4)
     mocha (1.1.0)

--- a/lib/ssf/base_client.rb
+++ b/lib/ssf/base_client.rb
@@ -42,7 +42,7 @@ module SSF
       if parent
         start_span_from_context(
           name: name,
-          tags: Hash[parent.tags].merge!(tags),
+          tags: parent.tags.to_h.merge!(tags),
           trace_id: parent.trace_id,
           parent_id: parent.id,
           indicator: indicator,


### PR DESCRIPTION
#### Summary

This updates the Travis config to test modern versions of Ruby (and their current point releases at that).  As part of this I had to update the `Gemfile.lock` to specify a modern protobuf that worked under Ruby 2.6.

#### Motivation

Try to un-bork travis.

#### Test plan

Gonna, like, run it on travis.


#### Rollout/monitoring/revert plan
N/A