### PR TITLE
Disable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-rvm:
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
-script: bundle exec rake test


### PR DESCRIPTION
Remove the .travis.yml file to disable Travis CI builds.